### PR TITLE
Moved routing details into App.js, little more cleanup

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,8 +1,16 @@
 import React, { Component } from 'react'
-import { Link } from 'react-router'
+import { Router, Route, IndexRoute, IndexRedirect, Link, browserHistory } from 'react-router'
+import { syncHistoryWithStore } from 'react-router-redux'
+import { Provider } from 'react-redux'
 
-import { HiddenOnlyAuth, VisibleOnlyAuth } from '../util/wrappers.js'
-import { LoginButton, LogoutButton } from '../components'
+import store from './store'
+import { UserIsAuthenticated, HiddenOnlyAuth, VisibleOnlyAuth } from '../util/wrappers.js'
+import { 
+  LoginButton, LogoutButton,
+  Home, Profile, EventDashboard, EventCreator, EventCheckinAttestor
+} from '../components'
+
+const history = syncHistoryWithStore(browserHistory, store)
 
 // Styles
 import './App.css'
@@ -10,45 +18,64 @@ import '../fonts/open-sans.css'
 import '../../semantic/dist/semantic.min.css'
 
 /**
- * @classdesc
- * The 'app' component wraps all individual pages with a navbar
+ * This is the App's root component, which specifies the routing etc.
+ * The Main component (previously called App) wrapping all of these
+ * routes is the MenuWrapper (defined below)
  */
-class App extends Component {
-  render() {
-    // Links to be displayed to logged in users
-    const OnlyAuthLinks = VisibleOnlyAuth(() =>
-      <ul className="navbar-right">
-        <li className="menu-item">
-          <Link to="/dashboard" className="menu-link">Dashboard</Link>
-        </li>
-        <li className="menu-item">
-          <Link to="/profile" className="menu-link">Profile</Link>
-        </li>
-        <LogoutButton />
-      </ul>
-    )
+const App = () => (
+  <Provider store={store}>
+    <Router history={history}>
+      <Route path="/" component={MenuWrapper}>
+        <IndexRoute component={Home} />
+        <Route path="dashboard" component={UserIsAuthenticated(EventDashboard)} />
+        <Route path="profile" component={UserIsAuthenticated(Profile)} />
+        <Route path="create" component={UserIsAuthenticated(EventCreator)} />
+        <Route path="checkin" component={UserIsAuthenticated(EventCheckinAttestor)} />
+      </Route>
+    </Router>
+  </Provider>
+)
 
-    // Links to be displayed to logged out users
-    const OnlyGuestLinks = HiddenOnlyAuth(() =>
-      <ul className="navbar-right">
-        <LoginButton>login</LoginButton>
-      </ul>
-    )
-
-    return (
-      <div className="App">
-        <nav className="navbar">
-          <div className="nav-heading">
-            <Link to="/">uPort Live</Link>
-          </div>
-          <OnlyGuestLinks />
-          <OnlyAuthLinks />
-        </nav>
-
-        {this.props.children}
-      </div>
-    );
-  }
-}
 
 export default App
+
+/**
+ * The MenuWrappre component wraps all individual pages with a navbar
+ * with conditional display for different links depending on Auth state
+ */
+const MenuWrapper = ({children}) => {
+  // Links to be displayed to logged in users
+  const OnlyAuthLinks = VisibleOnlyAuth(() =>
+    <ul className="navbar-right">
+      <li className="menu-item">
+        <Link to="/dashboard" className="menu-link">Dashboard</Link>
+      </li>
+      <li className="menu-item">
+        <Link to="/profile" className="menu-link">Profile</Link>
+      </li>
+      <LogoutButton />
+    </ul>
+  )
+
+  // Links to be displayed to logged out users
+  const OnlyGuestLinks = HiddenOnlyAuth(() =>
+    <ul className="navbar-right">
+      <LoginButton>login</LoginButton>
+    </ul>
+  )
+
+  return (
+    <div className="App">
+      <nav className="navbar">
+        <div className="nav-heading">
+          <Link to="/">uPort Live</Link>
+        </div>
+        <OnlyGuestLinks />
+        <OnlyAuthLinks />
+      </nav>
+
+      {children}
+    </div>
+  );
+}
+

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,4 +1,3 @@
 import App from './App'
-import store from './store'
 
-export {App, store}
+export default App

--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,9 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Provider } from 'react-redux'
-import { syncHistoryWithStore } from 'react-router-redux'
-import { Router, Route, IndexRoute, browserHistory } from 'react-router'
 
-import { App, store } from './app'
-import { UserIsAuthenticated } from './util/wrappers.js'
-import { Home, Profile, EventDashboard, EventCreator, EventCheckinAttestor } from './components'
+import App from './app'
 
-const history = syncHistoryWithStore(browserHistory, store)
-
-// TODO: Maybe this goes in app as well ? 
-ReactDOM.render((
-    <Provider store={store}>
-      <Router history={history}>
-        <Route path="/" component={App}>
-          <IndexRoute component={Home} />
-          <Route path="dashboard" component={UserIsAuthenticated(EventDashboard)} />
-          <Route path="profile" component={UserIsAuthenticated(Profile)} />
-          <Route path="create" component={UserIsAuthenticated(EventCreator)} />
-          <Route path="checkin" component={UserIsAuthenticated(EventCheckinAttestor)} />
-        </Route>
-      </Router>
-    </Provider>
-  ),
+ReactDOM.render(
+  React.createElement(App), 
   document.getElementById('root')
 )


### PR DESCRIPTION
One more move on the restructure, made `src/index.js` pretty much a dummy file, doing the single call to `ReactDOM.render()`.  All routing info is now in `src/app/App.js`